### PR TITLE
array key [0] never exists

### DIFF
--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -20,8 +20,8 @@ class RequestException extends \Exception {
     {
         $this->requestBody = $requestBody;
         $error = json_decode($requestBody, true);
-        $this->errorCode = $error[0]['errorCode'];
-        parent::__construct($error[0]['message']);
+        $this->errorCode = $error['errorCode'];
+        parent::__construct($error['message']);
     }
 
     /**


### PR DESCRIPTION
When throwing an exception, a Notice is thrown because array key 0 doesn't exist.

Here's the error that's trying to be thrown.

`Array ( [error_description] => redirect_uri must match configuration [error] => redirect_uri_mismatch )`