### PR TITLE
add method for retrieving BLOB fields

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 use Crunch\Salesforce\Exceptions\RequestException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use Crunch\Salesforce\Exceptions\AuthenticationException;
+use GuzzleHttp\Psr7\Response;
 
 class Client
 {
@@ -80,6 +81,22 @@ class Client
         $response = $this->makeRequest('get', $url, ['headers' => ['Authorization' => $this->getAuthHeader()]]);
 
         return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Fetch a blob field of a specific object
+     *
+     * @param string $objectType
+     * @param string $sfId
+     * @param string $blobField
+     * @return Response
+     */
+    public function getBlob($objectType, $sfId, $blobField)
+    {
+        $url      = $this->baseUrl . '/services/data/v20.0/sobjects/' . $objectType . '/' . $sfId . '/' . $blobField;
+        $response = $this->makeRequest('get', $url, ['headers' => ['Authorization' => $this->getAuthHeader()]]);
+
+        return $response;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -48,6 +48,29 @@ class ClientTest extends TestCase {
     }
 
     /** @test */
+    public function client_will_get_blob_field()
+    {
+        $recordId = 'abc' . rand(1000, 9999999);
+
+        $response = new \GuzzleHttp\Psr7\Response(200, array('Content-Type' => 'text/plain'), 'test response body');
+
+
+        $guzzle = m::mock('\GuzzleHttp\Client');
+        //Make sure the url contains the passed in data
+        $guzzle->shouldReceive('get')->with(stringContainsInOrder("sobjects/Test/{$recordId}/blobField") , \Mockery::type('array'))->once()->andReturn($response);
+
+
+        $sfClient = new \Crunch\Salesforce\Client($this->getClientConfigMock(), $guzzle);
+        $sfClient->setAccessToken($this->getAccessTokenMock());
+
+
+        $data = $sfClient->getBlob('Test', $recordId, 'blobField');
+
+        $this->assertEquals('test response body', $data->getBody());
+        $this->assertEquals(['text/plain'], $data->getHeader('Content-Type'));
+    }
+
+    /** @test */
     public function client_can_search()
     {
         $response = m::mock('Psr\Http\Message\ResponseInterface');


### PR DESCRIPTION
Return a `\GuzzleHttp\Psr7\Response` from where you can extract the body and Content-Type header